### PR TITLE
Fix run-local script path

### DIFF
--- a/llama-operator/hack/run-local.sh
+++ b/llama-operator/hack/run-local.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+kubectl apply -f "$REPO_ROOT/config/crd/bases"
+kubectl apply -f "$REPO_ROOT/config/rbac"
+kubectl apply -f "$REPO_ROOT/config/manager"


### PR DESCRIPTION
## Summary
- add a run-local script under `llama-operator/hack`
- apply k8s configs from `../config` relative to the operator directory

## Testing
- `./llama-operator/hack/run-local.sh` *(fails: kubectl not found)*
- `(cd llama-operator && hack/run-local.sh)` *(fails: kubectl not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854562376e083319487223345fc64c7